### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,9 @@
             "email": "jordan@JaycoDesign.co.nz"
         }
     ],
-    "require": {},
+    "require": {
+        "ext-bcmath": "*"
+    },
     "require-dev": {
         "phpunit/phpunit": "4.0.*"
     },


### PR DESCRIPTION
As BCMath is not included in PHP by default anymore, this will prevent the package from being installed in an environment where it'll throw errors around missing `bc*()` functions.
